### PR TITLE
document log_einsum and (renamed) log_viterbi_einsum

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,8 @@ Note that unlike in NumPy or PyTorch, equations are pre-compiled using
 :py:func:`~torch_semiring_einsum.compile_equation` rather than re-parsed from
 scratch every time einsum is called.
 
+In addition to `einsum`, the module also exposes a differentiable `log_einsum` and a non-differentiable `log_viterbi_einsum`.
+
 API Documentation
 -----------------
 

--- a/torch_semiring_einsum/__init__.py
+++ b/torch_semiring_einsum/__init__.py
@@ -21,6 +21,8 @@ This combines :py:func:`log_einsum_forward` and
 :py:func:`log_einsum_backward` into one auto-differentiable function.
 """
 
+log_viterbi_einsum = log_viterbi_einsum_forward
+
 __all__ = [
     'compile_equation',
     'real_einsum_forward',
@@ -29,7 +31,7 @@ __all__ = [
     'log_einsum_forward',
     'log_einsum_backward',
     'log_einsum',
-    'log_viterbi_einsum_forward',
+    'log_viterbi_einsum',
     'semiring_einsum_forward',
     'combine'
 ]


### PR DESCRIPTION
- Add `log_einsum` (presumably the most common case) to documentation

- IMO `_forward` and `_backward` are low_level details so I also renamed `log_viterbi_einsum_forward` to `log_viterbi_einsum`. Feel free to reject this.


