### PR TITLE
Allow zero-dimensional arguments

### DIFF
--- a/tests/test_semiring_einsum.py
+++ b/tests/test_semiring_einsum.py
@@ -204,6 +204,8 @@ class TestSemiringEinsum(unittest.TestCase):
         eq = compile_equation('->')
         ans = einsum(eq, torch.tensor(1.), block_size=1)
         self.assertAlmostEqual(ans.item(), 1.)
+        ans = log_einsum(eq, torch.tensor(2.), block_size=1)
+        self.assertAlmostEqual(ans.item(), 2.)
 
 def reference_log_viterbi_einsum(X1, X2, X3, device):
     Y_max = []

--- a/tests/test_semiring_einsum.py
+++ b/tests/test_semiring_einsum.py
@@ -200,6 +200,11 @@ class TestSemiringEinsum(unittest.TestCase):
         numpy.testing.assert_allclose(maxval, expected_maxval)
         self.assertTrue(torch.equal(argmax, expected_argmax))
 
+    def test_zero_dim(self):
+        eq = compile_equation('->')
+        ans = einsum(eq, torch.tensor(1.), block_size=1)
+        self.assertAlmostEqual(ans.item(), 1.)
+
 def reference_log_viterbi_einsum(X1, X2, X3, device):
     Y_max = []
     Y_argmax = []

--- a/torch_semiring_einsum/equation.py
+++ b/torch_semiring_einsum/equation.py
@@ -156,7 +156,7 @@ class LookupInfo:
             index[dest_index] = var_values[source_index]
         for i in range(self.num_extra_vars):
             index.append(None)
-        return arg[index].permute(self.permutation)
+        return arg[tuple(index)].permute(self.permutation)
 
 def create_reduce_info(input_vars, output_vars):
     r"""Pre-compile a data structure that will help reduce the variables

--- a/torch_semiring_einsum/extend.py
+++ b/torch_semiring_einsum/extend.py
@@ -166,7 +166,8 @@ def semiring_einsum_forward_impl(equation, args, block_size, inputs,
     return reduce_in_place(add_in_place, generate_terms())
 
 def adjust_size(arg, size):
-    if arg.ndim == 0: return arg
+    if arg.ndim == 0:
+        return arg.clone()
     repeat_size = []
     for output_size, arg_size in zip(size, arg.size()):
         repeat_size.append(output_size if arg_size == 1 else 1)

--- a/torch_semiring_einsum/extend.py
+++ b/torch_semiring_einsum/extend.py
@@ -166,6 +166,7 @@ def semiring_einsum_forward_impl(equation, args, block_size, inputs,
     return reduce_in_place(add_in_place, generate_terms())
 
 def adjust_size(arg, size):
+    if arg.ndim == 0: return arg
     repeat_size = []
     for output_size, arg_size in zip(size, arg.size()):
         repeat_size.append(output_size if arg_size == 1 else 1)


### PR DESCRIPTION
Closes #7.

This turned out to be a bug in PyTorch:

```
>>> torch.tensor(1.)[()]
tensor(1.)
>>> torch.tensor(1.)[[]]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: too many indices for tensor of dimension 0
>>> torch.tensor([1.])[(0,)]
tensor(1.)
>>> torch.tensor([1.])[[0]]
tensor([1.])
```

This PR just works around that bug.
