### PR TITLE
Use torch.amax if available

### DIFF
--- a/torch_semiring_einsum/utils.py
+++ b/torch_semiring_einsum/utils.py
@@ -19,10 +19,7 @@ def sum_block(a, dims):
         return a
 
 def max_block(a, dims):
-    result = a
-    for dim in reversed(dims):
-        result = torch.max(result, dim=dim).values
-    return result
+    return amax(a, dims)
 
 def clip_max_values(max_values):
     # Clipping to `min_float` fixes an edge case where all terms are -inf
@@ -34,3 +31,16 @@ def resize_max_values(max_values, num_reduced_vars):
     # Resize max_values so it can broadcast with the shape
     # output_vars + reduced_vars.
     return max_values.view(list(max_values.size()) + [1] * num_reduced_vars)
+
+def amax(a, dim, keepdim=False):
+    """Find the maximum of a tensor over zero or more dimensions."""
+    try:
+        # PyTorch >= 1.10
+        result = torch.amax(a, dim=dim, keepdim=keepdim)
+    except AttributeError:
+        # PyTorch < 1.10
+        result = a
+        for dim in reversed(dims):
+            result = torch.max(result, dim=dim, keepdim=keepdim).values
+    return result
+


### PR DESCRIPTION
torch.amax can take a max over multiple dims, which ought to be faster than using torch.max on one dim at a time.

I don't think there's a similar solution for log_viterbi_einsum_forward, since amax doesn't return an argmax.