### PR TITLE
Avoid the call to permute in LookupInfo.lookup

### DIFF
--- a/torch_semiring_einsum/equation.py
+++ b/torch_semiring_einsum/equation.py
@@ -150,13 +150,32 @@ class LookupInfo:
         self.num_extra_vars = num_extra_vars
         self.permutation = permutation
 
+        n = max((1 + source_index for source_index, dest_index in index_map),
+                default=0)
+        self.source_to_dest = [None] * n
+        for source_index, dest_index in index_map:
+            self.source_to_dest[source_index] = dest_index
+
     def lookup(self, arg, var_values):
         index = [_COLON] * arg.dim()
         for source_index, dest_index in self.index_map:
+            assert(dest_index == self.permutation[arg.ndim + self.num_extra_vars - len(var_values) + source_index])
             index[dest_index] = var_values[source_index]
         for i in range(self.num_extra_vars):
             index.append(None)
         return arg[tuple(index)].permute(self.permutation)
+
+    def view(self, arg):
+        for i in range(self.num_extra_vars):
+            arg = arg.unsqueeze(-1)
+        return arg.permute(self.permutation)
+
+    def view_lookup(self, argv, var_values):
+        # TODO: generate this code in __init__ using ast
+        return argv[tuple(itertools.chain(
+            (Ellipsis,),
+            (_COLON if dest_index is None else var_value
+             for dest_index, var_value in itertools.zip_longest(self.source_to_dest, var_values))))]
 
 def create_reduce_info(input_vars, output_vars):
     r"""Pre-compile a data structure that will help reduce the variables

--- a/torch_semiring_einsum/extend.py
+++ b/torch_semiring_einsum/extend.py
@@ -135,15 +135,18 @@ def semiring_einsum_forward_impl(equation, args, block_size, inputs,
         include_indexes):
     var_ranges = reduce_info.get_ranges(equation, args, block_size)
 
+    inputs_viewed = [arg_info.view(arg)
+                     for arg, arg_info in zip(inputs, reduce_info.lookup_info)]
+
     def generate_terms():
         for var_values in itertools.product(*var_ranges):
 
             def generate_factors():
-                for arg, arg_info in zip(inputs, reduce_info.lookup_info):
+                for argv, arg_info in zip(inputs_viewed, reduce_info.lookup_info):
                     # Get a slice of arg based on the current values of the
                     # reduced variables. The result has a shape of
                     # output_vars x reduced_vars.
-                    yield arg_info.lookup(arg, var_values)
+                    yield arg_info.view_lookup(argv, var_values)
 
             term_size = reduce_info.get_term_size(equation, args, var_values)
             # Multiply the args together.


### PR DESCRIPTION
Call `unsqueeze` and `permute` ahead of time in `LookupInfo.view`, then just index into the result in `view_lookup` instead of `lookup`

This speeds up https://github.com/diprism/fggs/blob/main/test/test_sum_product.py by ~10%